### PR TITLE
Add comprehensive unit and E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
-  workflow_run:
-    workflows: ["Fetch YouTube Videos"]
-    types: [completed]
-    branches: [main]
+    tags:
+      - 'v*'
 
 permissions:
   pages: write
@@ -19,9 +16,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
     environment:
       name: github-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: gallery/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: gallery
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: gallery
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        working-directory: gallery
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: gallery/playwright-report/
+          retention-days: 14

--- a/fetch/pyproject.toml
+++ b/fetch/pyproject.toml
@@ -8,3 +8,8 @@ dependencies = [
     "google-auth-httplib2>=0.3.0",
     "google-auth-oauthlib>=1.2.4",
 ]
+
+[tool.pytest.ini_options]
+# Unit tests mock all external Google API dependencies, so no credentials or
+# network access are required. Run with: python3 -m pytest fetch/tests/
+testpaths = ["tests"]

--- a/fetch/tests/test_fetch_videos.py
+++ b/fetch/tests/test_fetch_videos.py
@@ -1,0 +1,420 @@
+"""
+Unit tests for fetch_videos.py.
+
+External Google API dependencies are fully mocked so no network access or
+credentials are required. Run with:
+  python3 -m pytest fetch/tests/  (from repo root)
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock Google SDK modules BEFORE importing fetch_videos so the module-level
+# `from google... import ...` statements succeed without the real packages.
+# ---------------------------------------------------------------------------
+
+for _mod in [
+    "google",
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.oauth2",
+    "google.oauth2.credentials",
+    "googleapiclient",
+    "googleapiclient.discovery",
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import fetch_videos  # noqa: E402 (must come after sys.modules patching)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_youtube_mock():
+    """Return a MagicMock that mimics the YouTube API client object."""
+    return MagicMock()
+
+
+def paginate(pages):
+    """
+    Given a list of page-dicts (each with an "items" key), wire up the
+    nextPageToken chain so that successive .execute() calls return each page.
+    """
+    for i, page in enumerate(pages):
+        if i < len(pages) - 1:
+            page["nextPageToken"] = f"token_{i}"
+        else:
+            page.pop("nextPageToken", None)
+    return pages
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_credentials
+# ---------------------------------------------------------------------------
+
+class TestGetCredentials:
+    def test_raises_if_token_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(fetch_videos, "TOKEN_FILE", tmp_path / "nonexistent_token.json")
+        with pytest.raises(FileNotFoundError, match="token.json"):
+            fetch_videos.get_credentials()
+
+    def test_returns_valid_credentials_without_refresh(self, tmp_path, monkeypatch):
+        token_path = tmp_path / "token.json"
+        token_path.write_text('{"token": "fake"}')
+        monkeypatch.setattr(fetch_videos, "TOKEN_FILE", token_path)
+
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.expired = False
+
+        with patch("fetch_videos.Credentials") as MockCreds:
+            MockCreds.from_authorized_user_file.return_value = mock_creds
+            result = fetch_videos.get_credentials()
+
+        assert result is mock_creds
+        # No refresh should have been triggered
+        mock_creds.refresh.assert_not_called()
+
+    def test_refreshes_expired_credentials_and_saves_token(self, tmp_path, monkeypatch):
+        token_path = tmp_path / "token.json"
+        token_path.write_text('{"token": "old"}')
+        monkeypatch.setattr(fetch_videos, "TOKEN_FILE", token_path)
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = "some_refresh_token"
+        mock_creds.to_json.return_value = '{"token": "refreshed"}'
+
+        with patch("fetch_videos.Credentials") as MockCreds, \
+             patch("fetch_videos.Request") as MockRequest:
+            MockCreds.from_authorized_user_file.return_value = mock_creds
+            fetch_videos.get_credentials()
+
+        mock_creds.refresh.assert_called_once()
+        assert token_path.read_text() == '{"token": "refreshed"}'
+
+    def test_does_not_refresh_when_no_refresh_token(self, tmp_path, monkeypatch):
+        token_path = tmp_path / "token.json"
+        token_path.write_text('{"token": "fake"}')
+        monkeypatch.setattr(fetch_videos, "TOKEN_FILE", token_path)
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = None
+
+        with patch("fetch_videos.Credentials") as MockCreds:
+            MockCreds.from_authorized_user_file.return_value = mock_creds
+            result = fetch_videos.get_credentials()
+
+        mock_creds.refresh.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_uploads_playlist_id
+# ---------------------------------------------------------------------------
+
+class TestGetUploadsPlaylistId:
+    def test_returns_uploads_playlist_id(self):
+        youtube = make_youtube_mock()
+        youtube.channels().list().execute.return_value = {
+            "items": [{
+                "contentDetails": {
+                    "relatedPlaylists": {"uploads": "UUxxxxxx"}
+                }
+            }]
+        }
+        result = fetch_videos.get_uploads_playlist_id(youtube)
+        assert result == "UUxxxxxx"
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_all_video_ids
+# ---------------------------------------------------------------------------
+
+class TestGetAllVideoIds:
+    def _make_page(self, video_ids, next_token=None):
+        page = {
+            "items": [
+                {"contentDetails": {"videoId": vid}} for vid in video_ids
+            ]
+        }
+        if next_token:
+            page["nextPageToken"] = next_token
+        return page
+
+    def test_single_page_no_pagination(self):
+        youtube = make_youtube_mock()
+        youtube.playlistItems().list().execute.return_value = self._make_page(
+            ["vid1", "vid2", "vid3"]
+        )
+        result = fetch_videos.get_all_video_ids(youtube, "PLxxxxxxx")
+        assert result == ["vid1", "vid2", "vid3"]
+
+    def test_multiple_pages_are_concatenated(self):
+        youtube = make_youtube_mock()
+        page1 = self._make_page(["vid1", "vid2"], next_token="token1")
+        page2 = self._make_page(["vid3", "vid4"])
+
+        youtube.playlistItems().list().execute.side_effect = [page1, page2]
+
+        result = fetch_videos.get_all_video_ids(youtube, "PLxxxxxxx")
+        assert result == ["vid1", "vid2", "vid3", "vid4"]
+
+    def test_three_pages(self):
+        youtube = make_youtube_mock()
+        page1 = self._make_page(["vid1"], next_token="t1")
+        page2 = self._make_page(["vid2"], next_token="t2")
+        page3 = self._make_page(["vid3"])
+
+        youtube.playlistItems().list().execute.side_effect = [page1, page2, page3]
+
+        result = fetch_videos.get_all_video_ids(youtube, "PLxxxxxxx")
+        assert result == ["vid1", "vid2", "vid3"]
+
+    def test_empty_playlist_returns_empty_list(self):
+        youtube = make_youtube_mock()
+        youtube.playlistItems().list().execute.return_value = {"items": []}
+        result = fetch_videos.get_all_video_ids(youtube, "PLxxxxxxx")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_video_details
+# ---------------------------------------------------------------------------
+
+class TestGetVideoDetails:
+    def _make_response(self, video_ids):
+        return {"items": [{"id": vid, "snippet": {"title": f"Title {vid}"}} for vid in video_ids]}
+
+    def test_empty_video_ids_returns_empty(self):
+        youtube = make_youtube_mock()
+        result = fetch_videos.get_video_details(youtube, [])
+        assert result == []
+        youtube.videos().list.assert_not_called()
+
+    def test_single_batch_under_50(self):
+        youtube = make_youtube_mock()
+        ids = [f"vid{i}" for i in range(10)]
+        # Use .return_value chaining to avoid polluting call counts
+        youtube.videos.return_value.list.return_value.execute.return_value = self._make_response(ids)
+
+        result = fetch_videos.get_video_details(youtube, ids)
+
+        assert len(result) == 10
+        # Only one API call (one batch)
+        youtube.videos.return_value.list.assert_called_once()
+        call_kwargs = youtube.videos.return_value.list.call_args[1]
+        assert call_kwargs["id"] == ",".join(ids)
+
+    def test_exactly_50_videos_single_batch(self):
+        youtube = make_youtube_mock()
+        ids = [f"vid{i}" for i in range(50)]
+        youtube.videos.return_value.list.return_value.execute.return_value = self._make_response(ids)
+
+        result = fetch_videos.get_video_details(youtube, ids)
+        assert len(result) == 50
+        youtube.videos.return_value.list.assert_called_once()
+
+    def test_51_videos_uses_two_batches(self):
+        youtube = make_youtube_mock()
+        ids = [f"vid{i}" for i in range(51)]
+        batch1_response = self._make_response(ids[:50])
+        batch2_response = self._make_response(ids[50:])
+
+        youtube.videos.return_value.list.return_value.execute.side_effect = [
+            batch1_response, batch2_response
+        ]
+
+        result = fetch_videos.get_video_details(youtube, ids)
+        assert len(result) == 51
+        assert youtube.videos.return_value.list.call_count == 2
+
+    def test_100_videos_uses_two_batches(self):
+        youtube = make_youtube_mock()
+        ids = [f"vid{i}" for i in range(100)]
+        batch1_response = self._make_response(ids[:50])
+        batch2_response = self._make_response(ids[50:])
+
+        youtube.videos().list().execute.side_effect = [batch1_response, batch2_response]
+
+        result = fetch_videos.get_video_details(youtube, ids)
+        assert len(result) == 100
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_all_playlists
+# ---------------------------------------------------------------------------
+
+class TestGetAllPlaylists:
+    def _make_page(self, playlist_ids, next_token=None):
+        page = {
+            "items": [
+                {"id": pid, "snippet": {"title": f"Playlist {pid}"}}
+                for pid in playlist_ids
+            ]
+        }
+        if next_token:
+            page["nextPageToken"] = next_token
+        return page
+
+    def test_single_page(self):
+        youtube = make_youtube_mock()
+        youtube.playlists().list().execute.return_value = self._make_page(["PL1", "PL2"])
+
+        result = fetch_videos.get_all_playlists(youtube)
+        assert len(result) == 2
+        assert result[0]["id"] == "PL1"
+
+    def test_multiple_pages(self):
+        youtube = make_youtube_mock()
+        page1 = self._make_page(["PL1", "PL2"], next_token="tok1")
+        page2 = self._make_page(["PL3"])
+        youtube.playlists().list().execute.side_effect = [page1, page2]
+
+        result = fetch_videos.get_all_playlists(youtube)
+        assert len(result) == 3
+        assert result[2]["id"] == "PL3"
+
+    def test_no_playlists_returns_empty(self):
+        youtube = make_youtube_mock()
+        youtube.playlists().list().execute.return_value = {"items": []}
+
+        result = fetch_videos.get_all_playlists(youtube)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_playlist_memberships
+# ---------------------------------------------------------------------------
+
+class TestGetPlaylistMemberships:
+    def _make_video_item(self, video_id):
+        return {
+            "snippet": {
+                "resourceId": {"kind": "youtube#video", "videoId": video_id}
+            }
+        }
+
+    def _make_non_video_item(self):
+        """An item that is not a video (e.g. a playlist reference)."""
+        return {
+            "snippet": {
+                "resourceId": {"kind": "youtube#playlist", "playlistId": "PLother"}
+            }
+        }
+
+    def _make_playlist(self, playlist_id, title):
+        return {"id": playlist_id, "snippet": {"title": title}}
+
+    def test_single_playlist_single_video(self):
+        youtube = make_youtube_mock()
+        youtube.playlistItems().list().execute.return_value = {
+            "items": [self._make_video_item("vid1")]
+        }
+        playlists = [self._make_playlist("PL1", "My Playlist")]
+
+        result = fetch_videos.get_playlist_memberships(youtube, playlists)
+
+        assert len(result) == 1
+        assert result[0] == {
+            "playlist_id": "PL1",
+            "playlist_title": "My Playlist",
+            "video_id": "vid1",
+        }
+
+    def test_non_video_items_are_filtered_out(self):
+        youtube = make_youtube_mock()
+        youtube.playlistItems().list().execute.return_value = {
+            "items": [
+                self._make_video_item("vid1"),
+                self._make_non_video_item(),
+                self._make_video_item("vid2"),
+            ]
+        }
+        playlists = [self._make_playlist("PL1", "My Playlist")]
+
+        result = fetch_videos.get_playlist_memberships(youtube, playlists)
+
+        # Only the two video items should appear
+        assert len(result) == 2
+        assert all(r["video_id"] in ("vid1", "vid2") for r in result)
+
+    def test_multiple_playlists(self):
+        youtube = make_youtube_mock()
+        # Each playlist gets its own items response
+        youtube.playlistItems().list().execute.side_effect = [
+            {"items": [self._make_video_item("vid1")]},
+            {"items": [self._make_video_item("vid2"), self._make_video_item("vid3")]},
+        ]
+        playlists = [
+            self._make_playlist("PL1", "Playlist One"),
+            self._make_playlist("PL2", "Playlist Two"),
+        ]
+
+        result = fetch_videos.get_playlist_memberships(youtube, playlists)
+
+        assert len(result) == 3
+        pl1_rows = [r for r in result if r["playlist_id"] == "PL1"]
+        pl2_rows = [r for r in result if r["playlist_id"] == "PL2"]
+        assert len(pl1_rows) == 1
+        assert len(pl2_rows) == 2
+
+    def test_pagination_within_playlist(self):
+        youtube = make_youtube_mock()
+        page1 = {
+            "items": [self._make_video_item("vid1")],
+            "nextPageToken": "token1",
+        }
+        page2 = {
+            "items": [self._make_video_item("vid2")],
+        }
+        youtube.playlistItems().list().execute.side_effect = [page1, page2]
+
+        playlists = [self._make_playlist("PL1", "Paginated Playlist")]
+        result = fetch_videos.get_playlist_memberships(youtube, playlists)
+
+        assert len(result) == 2
+        assert {r["video_id"] for r in result} == {"vid1", "vid2"}
+
+    def test_empty_playlist_produces_no_memberships(self):
+        youtube = make_youtube_mock()
+        youtube.playlistItems().list().execute.return_value = {"items": []}
+
+        playlists = [self._make_playlist("PL1", "Empty Playlist")]
+        result = fetch_videos.get_playlist_memberships(youtube, playlists)
+        assert result == []
+
+    def test_no_playlists_returns_empty(self):
+        youtube = make_youtube_mock()
+        result = fetch_videos.get_playlist_memberships(youtube, [])
+        assert result == []
+        youtube.playlistItems().list.assert_not_called()
+
+    def test_video_in_multiple_playlists_creates_multiple_rows(self):
+        """The same video_id appearing in two playlists → two membership rows."""
+        youtube = make_youtube_mock()
+        youtube.playlistItems().list().execute.side_effect = [
+            {"items": [self._make_video_item("shared_vid")]},
+            {"items": [self._make_video_item("shared_vid")]},
+        ]
+        playlists = [
+            self._make_playlist("PL1", "First"),
+            self._make_playlist("PL2", "Second"),
+        ]
+
+        result = fetch_videos.get_playlist_memberships(youtube, playlists)
+        assert len(result) == 2
+        assert result[0]["video_id"] == "shared_vid"
+        assert result[1]["video_id"] == "shared_vid"
+        assert result[0]["playlist_id"] != result[1]["playlist_id"]

--- a/fetch/tests/test_make_simple_video_list.py
+++ b/fetch/tests/test_make_simple_video_list.py
@@ -1,0 +1,323 @@
+"""
+Unit tests for make_simple_video_list.py.
+
+Run with: python3 -m pytest fetch/tests/ (from repo root)
+         or: python3 -m pytest (from fetch/ directory)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the fetch/ directory to the path so we can import the module under test
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from make_simple_video_list import build_membership_lookup, simplify_video
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+def make_membership(video_id, playlist_id, playlist_title):
+    return {
+        "video_id": video_id,
+        "playlist_id": playlist_id,
+        "playlist_title": playlist_title,
+    }
+
+
+def make_raw_video(
+    video_id="vid1",
+    title="Test Video",
+    description="A test description",
+    published_at="2024-01-15T10:00:00Z",
+    tags=None,
+    privacy_status="public",
+    channel_id="UCchannel123",
+    category_id="22",
+    view_count="100",
+    high_thumb=None,
+    standard_thumb=None,
+):
+    """Build a minimal raw YouTube API video resource."""
+    thumbnails = {}
+    if high_thumb is not None:
+        thumbnails["high"] = high_thumb
+    if standard_thumb is not None:
+        thumbnails["standard"] = standard_thumb
+
+    video = {
+        "id": video_id,
+        "snippet": {
+            "title": title,
+            "description": description,
+            "publishedAt": published_at,
+            "channelId": channel_id,
+            "thumbnails": thumbnails,
+        },
+        "status": {
+            "privacyStatus": privacy_status,
+        },
+        "statistics": {
+            "viewCount": view_count,
+        },
+    }
+    if tags is not None:
+        video["snippet"]["tags"] = tags
+    if category_id is not None:
+        video["snippet"]["categoryId"] = category_id
+
+    return video
+
+
+THUMB_HIGH = {"url": "https://i.ytimg.com/vi/vid1/hqdefault.jpg", "width": 480, "height": 360}
+THUMB_STANDARD = {"url": "https://i.ytimg.com/vi/vid1/sddefault.jpg", "width": 640, "height": 480}
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_membership_lookup
+# ---------------------------------------------------------------------------
+
+class TestBuildMembershipLookup:
+    def test_empty_memberships(self):
+        result = build_membership_lookup({"memberships": []})
+        assert result == {}
+
+    def test_single_membership(self):
+        memberships = [make_membership("vid1", "PL1", "My Playlist")]
+        result = build_membership_lookup({"memberships": memberships})
+        assert result["vid1"] == [{"id": "PL1", "title": "My Playlist"}]
+
+    def test_video_in_multiple_playlists(self):
+        memberships = [
+            make_membership("vid1", "PL1", "Playlist One"),
+            make_membership("vid1", "PL2", "Playlist Two"),
+        ]
+        result = build_membership_lookup({"memberships": memberships})
+        assert len(result["vid1"]) == 2
+        assert {"id": "PL1", "title": "Playlist One"} in result["vid1"]
+        assert {"id": "PL2", "title": "Playlist Two"} in result["vid1"]
+
+    def test_multiple_videos_in_different_playlists(self):
+        memberships = [
+            make_membership("vid1", "PL1", "Playlist One"),
+            make_membership("vid2", "PL2", "Playlist Two"),
+        ]
+        result = build_membership_lookup({"memberships": memberships})
+        assert result["vid1"] == [{"id": "PL1", "title": "Playlist One"}]
+        assert result["vid2"] == [{"id": "PL2", "title": "Playlist Two"}]
+
+    def test_video_not_in_lookup_returns_empty_list(self):
+        memberships = [make_membership("vid1", "PL1", "Playlist One")]
+        result = build_membership_lookup({"memberships": memberships})
+        # A video not in any playlist should not be in the lookup
+        assert result.get("vid_missing") is None
+        # The defaultdict behavior: accessing missing key returns []
+        assert result["vid_missing"] == []
+
+    def test_preserves_playlist_title(self):
+        title = "Family & Friends — Summer 2024"
+        memberships = [make_membership("vid1", "PL99", title)]
+        result = build_membership_lookup({"memberships": memberships})
+        assert result["vid1"][0]["title"] == title
+
+
+# ---------------------------------------------------------------------------
+# Tests for simplify_video
+# ---------------------------------------------------------------------------
+
+class TestSimplifyVideo:
+    def test_full_data_produces_correct_output(self):
+        raw = make_raw_video(
+            video_id="abc123",
+            title="My Great Video",
+            description="A thorough description.",
+            published_at="2024-03-01T14:00:00Z",
+            tags=["tutorial", "python"],
+            privacy_status="public",
+            channel_id="UCxyz",
+            category_id="28",
+            view_count="4321",
+            high_thumb=THUMB_HIGH,
+            standard_thumb=THUMB_STANDARD,
+        )
+        lookup = {"abc123": [{"id": "PL1", "title": "Tech Talks"}]}
+
+        result = simplify_video(raw, lookup)
+
+        assert result["id"] == "abc123"
+        assert result["url"] == "https://www.youtube.com/watch?v=abc123"
+        assert result["title"] == "My Great Video"
+        assert result["description"] == "A thorough description."
+        assert result["uploadDate"] == "2024-03-01T14:00:00Z"
+        assert result["tags"] == ["tutorial", "python"]
+        assert result["privacyStatus"] == "public"
+        assert result["thumbnails"]["high"] == THUMB_HIGH
+        assert result["thumbnails"]["standard"] == THUMB_STANDARD
+        assert result["channelId"] == "UCxyz"
+        assert result["categoryId"] == "28"
+        assert result["viewCount"] == "4321"
+        assert result["playlists"] == [{"id": "PL1", "title": "Tech Talks"}]
+
+    def test_url_constructed_from_video_id(self):
+        raw = make_raw_video(video_id="dQw4w9WgXcQ")
+        result = simplify_video(raw, {})
+        assert result["url"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_missing_tags_defaults_to_empty_list(self):
+        raw = make_raw_video(tags=None)
+        result = simplify_video(raw, {})
+        assert result["tags"] == []
+
+    def test_missing_statistics_view_count_defaults_to_zero(self):
+        raw = make_raw_video()
+        del raw["statistics"]
+        result = simplify_video(raw, {})
+        assert result["viewCount"] == "0"
+
+    def test_zero_view_count_in_statistics(self):
+        raw = make_raw_video(view_count="0")
+        del raw["statistics"]["viewCount"]
+        result = simplify_video(raw, {})
+        assert result["viewCount"] == "0"
+
+    def test_standard_thumbnail_used_when_present(self):
+        raw = make_raw_video(high_thumb=THUMB_HIGH, standard_thumb=THUMB_STANDARD)
+        result = simplify_video(raw, {})
+        assert result["thumbnails"]["standard"] == THUMB_STANDARD
+        assert result["thumbnails"]["high"] == THUMB_HIGH
+
+    def test_standard_thumbnail_falls_back_to_high(self):
+        """When standard thumbnail is absent, standard in output should be same as high."""
+        raw = make_raw_video(high_thumb=THUMB_HIGH, standard_thumb=None)
+        result = simplify_video(raw, {})
+        assert result["thumbnails"]["high"] == THUMB_HIGH
+        # standard falls back to high when not present
+        assert result["thumbnails"]["standard"] == THUMB_HIGH
+
+    def test_both_thumbnails_absent(self):
+        raw = make_raw_video(high_thumb=None, standard_thumb=None)
+        result = simplify_video(raw, {})
+        assert result["thumbnails"]["high"] is None
+        assert result["thumbnails"]["standard"] is None
+
+    def test_no_playlists_returns_empty_list(self):
+        raw = make_raw_video(video_id="lonely_vid")
+        result = simplify_video(raw, {})
+        assert result["playlists"] == []
+
+    def test_playlists_attached_from_lookup(self):
+        raw = make_raw_video(video_id="vid1")
+        lookup = {
+            "vid1": [
+                {"id": "PLA", "title": "Alpha"},
+                {"id": "PLB", "title": "Beta"},
+            ]
+        }
+        result = simplify_video(raw, lookup)
+        assert len(result["playlists"]) == 2
+        assert {"id": "PLA", "title": "Alpha"} in result["playlists"]
+
+    def test_privacy_status_preserved(self):
+        for status in ("public", "unlisted", "private"):
+            raw = make_raw_video(privacy_status=status)
+            result = simplify_video(raw, {})
+            assert result["privacyStatus"] == status
+
+    def test_empty_description(self):
+        raw = make_raw_video(description="")
+        result = simplify_video(raw, {})
+        assert result["description"] == ""
+
+    def test_missing_description_defaults_to_empty_string(self):
+        raw = make_raw_video()
+        del raw["snippet"]["description"]
+        result = simplify_video(raw, {})
+        assert result["description"] == ""
+
+    def test_category_id_none_when_absent(self):
+        # make_raw_video(category_id=None) already omits the key from snippet
+        raw = make_raw_video(category_id=None)
+        assert "categoryId" not in raw["snippet"]
+        result = simplify_video(raw, {})
+        assert result["categoryId"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration-style test for main() using tmp_path
+# ---------------------------------------------------------------------------
+
+class TestMainIntegration:
+    def test_main_reads_inputs_and_writes_outputs(self, tmp_path, monkeypatch):
+        """main() should read videos_full.json + playlists_full.json,
+        split public/private, and write both output files."""
+        import make_simple_video_list as msl
+
+        # Redirect all Path constants to tmp_path
+        videos_full = [
+            make_raw_video(video_id="pub1", privacy_status="public", high_thumb=THUMB_HIGH),
+            make_raw_video(video_id="pub2", privacy_status="unlisted", high_thumb=THUMB_HIGH),
+            make_raw_video(video_id="priv1", privacy_status="private", high_thumb=THUMB_HIGH),
+        ]
+        playlists_full = {
+            "playlists": [],
+            "memberships": [
+                make_membership("pub1", "PL1", "My Playlist"),
+            ],
+        }
+
+        videos_full_path = tmp_path / "videos_full.json"
+        playlists_full_path = tmp_path / "playlists_full.json"
+        output_path = tmp_path / "videos.json"
+        private_path = tmp_path / "videos_private.json"
+
+        videos_full_path.write_text(json.dumps(videos_full))
+        playlists_full_path.write_text(json.dumps(playlists_full))
+
+        monkeypatch.setattr(msl, "VIDEOS_FULL_FILE", videos_full_path)
+        monkeypatch.setattr(msl, "PLAYLISTS_FULL_FILE", playlists_full_path)
+        monkeypatch.setattr(msl, "OUTPUT_FILE", output_path)
+        monkeypatch.setattr(msl, "PRIVATE_FILE", private_path)
+
+        msl.main()
+
+        public_videos = json.loads(output_path.read_text())
+        private_videos = json.loads(private_path.read_text())
+
+        # public + unlisted → 2 videos in output
+        assert len(public_videos) == 2
+        assert all(v["privacyStatus"] != "private" for v in public_videos)
+
+        # 1 private video
+        assert len(private_videos) == 1
+        assert private_videos[0]["privacyStatus"] == "private"
+
+        # Playlist membership attached to pub1
+        pub1 = next(v for v in public_videos if v["id"] == "pub1")
+        assert pub1["playlists"] == [{"id": "PL1", "title": "My Playlist"}]
+
+    def test_main_raises_if_videos_full_missing(self, tmp_path, monkeypatch):
+        import make_simple_video_list as msl
+
+        # Use the real filename so the error message contains "videos_full.json"
+        monkeypatch.setattr(msl, "VIDEOS_FULL_FILE", tmp_path / "videos_full.json")
+        monkeypatch.setattr(msl, "PLAYLISTS_FULL_FILE", tmp_path / "playlists_full.json")
+
+        with pytest.raises(FileNotFoundError, match="videos_full.json"):
+            msl.main()
+
+    def test_main_raises_if_playlists_full_missing(self, tmp_path, monkeypatch):
+        import make_simple_video_list as msl
+
+        videos_full_path = tmp_path / "videos_full.json"
+        videos_full_path.write_text("[]")
+
+        monkeypatch.setattr(msl, "VIDEOS_FULL_FILE", videos_full_path)
+        # Use the real filename so the error message contains "playlists_full.json"
+        monkeypatch.setattr(msl, "PLAYLISTS_FULL_FILE", tmp_path / "playlists_full.json")
+
+        with pytest.raises(FileNotFoundError, match="playlists_full.json"):
+            msl.main()

--- a/gallery/.gitignore
+++ b/gallery/.gitignore
@@ -21,3 +21,7 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright
+test-results/
+playwright-report/

--- a/gallery/package-lock.json
+++ b/gallery/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "gallery",
 			"version": "0.0.1",
 			"devDependencies": {
+				"@playwright/test": "^1.56.0",
 				"@skeletonlabs/skeleton": "^4.12.0",
 				"@skeletonlabs/skeleton-svelte": "^4.12.0",
 				"@sveltejs/adapter-auto": "^7.0.0",
@@ -498,7 +499,6 @@
 			"integrity": "sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -551,6 +551,22 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.56.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+			"integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.56.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -1011,7 +1027,6 @@
 			"integrity": "sha512-Brh/9h8QEg7rWIj+Nnz/2sC49NUeS8g3Qd9H5dTO3EbWG8vCEUl06jE+r5jQVDMHdr1swmCkwZkONFsWelGTpQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1054,7 +1069,6 @@
 			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"deepmerge": "^4.3.1",
@@ -2006,7 +2020,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2233,7 +2246,6 @@
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -2254,7 +2266,6 @@
 			"integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
 			"dev": true,
 			"license": "MPL-2.0",
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -2590,12 +2601,58 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.56.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+			"integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.56.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.56.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+			"integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -2744,7 +2801,6 @@
 			"integrity": "sha512-7dhHkSamGS2vtoBmIW2hRab+gl5Z60alEHZB4910ePqqJNxAWnDAxsofVmlZ2tREmWyHNE+A1nCKwICAquoD2A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2796,8 +2852,7 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
 			"integrity": "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -2853,7 +2908,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2868,7 +2922,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -9,9 +9,13 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:debug": "playwright test --debug"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.56.0",
 		"@skeletonlabs/skeleton": "^4.12.0",
 		"@skeletonlabs/skeleton-svelte": "^4.12.0",
 		"@sveltejs/adapter-auto": "^7.0.0",

--- a/gallery/playwright.config.ts
+++ b/gallery/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E test configuration for the gallery SvelteKit app.
+ *
+ * Tests mock the /videos.json fetch to avoid network dependencies.
+ * Run with: npm run test:e2e
+ */
+export default defineConfig({
+	testDir: './tests',
+
+	// Run each test file in parallel; tests within a file run serially
+	fullyParallel: false,
+
+	// Fail the build on CI if test.only is accidentally left in
+	forbidOnly: !!process.env.CI,
+
+	// No retries — tests should be deterministic
+	retries: 0,
+
+	// Use a single worker in CI for stability; local runs can use more
+	workers: process.env.CI ? 1 : undefined,
+
+	reporter: [['list'], ['html', { open: 'never' }]],
+
+	use: {
+		baseURL: 'http://localhost:5173',
+
+		// Collect traces on failure for debugging
+		trace: 'on-first-retry',
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+
+	// Start the SvelteKit dev server before running tests.
+	// The dev server serves the app without building to static files,
+	// which is intentional — we want fast test startup.
+	webServer: {
+		command: 'npm run dev',
+		url: 'http://localhost:5173',
+		// Reuse an already-running server for faster local development
+		reuseExistingServer: !process.env.CI,
+		timeout: 60_000,
+	},
+});

--- a/gallery/tests/admin.spec.ts
+++ b/gallery/tests/admin.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, type Page } from '@playwright/test';
+import { sampleVideos } from './fixtures/sample-videos.js';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function mockVideos(page: Page, videos: typeof sampleVideos = sampleVideos) {
+	await page.route('**/videos.json', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(videos),
+		});
+	});
+}
+
+async function mockVideosError(page: Page, status = 500) {
+	await page.route('**/videos.json', async (route) => {
+		await route.fulfill({ status, body: 'Internal Server Error' });
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Admin page — structure & navigation
+// ---------------------------------------------------------------------------
+
+test.describe('Admin page — layout and navigation', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/admin');
+	});
+
+	test('renders the browser tab title', async ({ page }) => {
+		await expect(page).toHaveTitle('Admin - Family Videos');
+	});
+
+	test('shows the Admin heading', async ({ page }) => {
+		await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible();
+	});
+
+	test('shows the site name in the navigation bar', async ({ page }) => {
+		await expect(page.getByRole('link', { name: 'Family Videos' })).toBeVisible();
+	});
+
+	test('Family Videos nav link points to the root', async ({ page }) => {
+		const navLink = page.getByRole('link', { name: 'Family Videos' });
+		const href = await navLink.getAttribute('href');
+		// In dev mode the base path is empty; href should be "/" or ""
+		expect(href === '/' || href === '').toBe(true);
+	});
+
+	test('shows "Refresh Video Data" button linking to GitHub Actions', async ({ page }) => {
+		const refreshLink = page.getByRole('link', { name: 'Refresh Video Data' });
+		await expect(refreshLink).toBeVisible();
+
+		const href = await refreshLink.getAttribute('href');
+		expect(href).toContain('github.com');
+		expect(href).toContain('fetch-videos.yml');
+	});
+
+	test('"Refresh Video Data" link opens in a new tab', async ({ page }) => {
+		const refreshLink = page.getByRole('link', { name: 'Refresh Video Data' });
+		await expect(refreshLink).toHaveAttribute('target', '_blank');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Admin page — video table
+// ---------------------------------------------------------------------------
+
+test.describe('Admin page — video table', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/admin');
+	});
+
+	test('renders a table with rows for each video', async ({ page }) => {
+		const rows = page.locator('tbody tr');
+		await expect(rows).toHaveCount(sampleVideos.length);
+	});
+
+	test('table has the expected column headers', async ({ page }) => {
+		// Use locator('th') since <th> implicit ARIA role varies by browser context
+		for (const header of ['Thumbnail', 'Title', 'Date', 'Status', 'Actions']) {
+			await expect(page.locator('thead th', { hasText: header })).toBeVisible();
+		}
+	});
+
+	test('shows video titles in the table', async ({ page }) => {
+		for (const video of sampleVideos) {
+			await expect(page.getByText(video.title)).toBeVisible();
+		}
+	});
+
+	test('shows privacy status badges for each video', async ({ page }) => {
+		// The two statuses in our fixture are "public" and "unlisted"
+		const publicBadges = page.getByText('public');
+		const unlistedBadges = page.getByText('unlisted');
+
+		await expect(publicBadges.first()).toBeVisible();
+		await expect(unlistedBadges.first()).toBeVisible();
+	});
+
+	test('shows "Edit in Studio" links for each video', async ({ page }) => {
+		const studioLinks = page.getByRole('link', { name: 'Edit in Studio' });
+		await expect(studioLinks).toHaveCount(sampleVideos.length);
+	});
+
+	test('"Edit in Studio" links point to YouTube Studio with correct video ID', async ({
+		page,
+	}) => {
+		const studioLinks = page.getByRole('link', { name: 'Edit in Studio' });
+		const count = await studioLinks.count();
+
+		for (let i = 0; i < count; i++) {
+			const href = await studioLinks.nth(i).getAttribute('href');
+			expect(href).toContain('studio.youtube.com/video/');
+			// Verify the URL contains one of our known video IDs
+			const hasKnownId = sampleVideos.some((v) => href?.includes(v.id));
+			expect(hasKnownId).toBe(true);
+		}
+	});
+
+	test('"Edit in Studio" links open in a new tab', async ({ page }) => {
+		const firstStudioLink = page.getByRole('link', { name: 'Edit in Studio' }).first();
+		await expect(firstStudioLink).toHaveAttribute('target', '_blank');
+	});
+
+	test('shows thumbnail images in the table', async ({ page }) => {
+		// At least one thumbnail image should be present
+		const thumbnails = page.locator('tbody img');
+		await expect(thumbnails.first()).toBeVisible();
+	});
+
+	test('upload date is displayed for each video', async ({ page }) => {
+		// Dates are rendered with toLocaleDateString() — just check the column cells exist
+		const dateCells = page.locator('tbody tr td:nth-child(3)');
+		await expect(dateCells).toHaveCount(sampleVideos.length);
+		for (let i = 0; i < sampleVideos.length; i++) {
+			const text = await dateCells.nth(i).textContent();
+			expect(text?.trim().length).toBeGreaterThan(0);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Admin page — error and empty states
+// ---------------------------------------------------------------------------
+
+test.describe('Admin page — error state', () => {
+	test('shows error message when videos.json fails', async ({ page }) => {
+		await mockVideosError(page);
+		await page.goto('/admin');
+
+		await expect(page.getByText(/Failed to fetch videos/)).toBeVisible();
+	});
+
+	test('does not show the table when loading fails', async ({ page }) => {
+		await mockVideosError(page);
+		await page.goto('/admin');
+
+		await expect(page.locator('table')).not.toBeVisible();
+	});
+});
+
+test.describe('Admin page — empty video list', () => {
+	test('shows an empty table body when there are no videos', async ({ page }) => {
+		await mockVideos(page, []);
+		await page.goto('/admin');
+
+		// Table should be present but have no rows
+		const rows = page.locator('tbody tr');
+		await expect(rows).toHaveCount(0);
+	});
+});

--- a/gallery/tests/fixtures/sample-videos.ts
+++ b/gallery/tests/fixtures/sample-videos.ts
@@ -1,0 +1,82 @@
+/**
+ * Sample video data used in Playwright E2E tests.
+ * Mirrors the shape of videos.json produced by make_simple_video_list.py.
+ */
+export const sampleVideos = [
+	{
+		id: 'vacationVid1',
+		url: 'https://www.youtube.com/watch?v=vacationVid1',
+		title: 'Family Vacation 2023',
+		description: 'Our summer trip to the beach. Fun in the sun!',
+		uploadDate: '2023-07-15T12:00:00Z',
+		tags: ['vacation', 'beach', 'summer'],
+		privacyStatus: 'public',
+		thumbnails: {
+			high: {
+				url: 'https://i.ytimg.com/vi/vacationVid1/hqdefault.jpg',
+				width: 480,
+				height: 360,
+			},
+			standard: {
+				url: 'https://i.ytimg.com/vi/vacationVid1/sddefault.jpg',
+				width: 640,
+				height: 480,
+			},
+		},
+		channelId: 'UCchannel123',
+		categoryId: '22',
+		viewCount: '42',
+		playlists: [{ id: 'PLvacations', title: 'Vacations' }],
+	},
+	{
+		id: 'birthdayVid2',
+		url: 'https://www.youtube.com/watch?v=birthdayVid2',
+		title: "Grandma's Birthday Party",
+		description: "Celebrating grandma turning 80. A wonderful day with family.",
+		uploadDate: '2023-09-20T15:30:00Z',
+		tags: ['birthday', 'party', 'grandma'],
+		privacyStatus: 'unlisted',
+		thumbnails: {
+			high: {
+				url: 'https://i.ytimg.com/vi/birthdayVid2/hqdefault.jpg',
+				width: 480,
+				height: 360,
+			},
+			standard: null,
+		},
+		channelId: 'UCchannel123',
+		categoryId: '22',
+		viewCount: '18',
+		playlists: [
+			{ id: 'PLbirthdays', title: 'Birthdays' },
+			{ id: 'PLvacations', title: 'Vacations' },
+		],
+	},
+	{
+		id: 'christmasVid3',
+		url: 'https://www.youtube.com/watch?v=christmasVid3',
+		title: 'Christmas Morning',
+		description: 'Opening presents on Christmas morning.',
+		uploadDate: '2023-12-25T08:00:00Z',
+		tags: ['christmas', 'holidays', 'presents'],
+		privacyStatus: 'public',
+		thumbnails: {
+			high: {
+				url: 'https://i.ytimg.com/vi/christmasVid3/hqdefault.jpg',
+				width: 480,
+				height: 360,
+			},
+			standard: {
+				url: 'https://i.ytimg.com/vi/christmasVid3/sddefault.jpg',
+				width: 640,
+				height: 480,
+			},
+		},
+		channelId: 'UCchannel123',
+		categoryId: '22',
+		viewCount: '156',
+		playlists: [],
+	},
+] as const;
+
+export type SampleVideo = (typeof sampleVideos)[number];

--- a/gallery/tests/gallery.spec.ts
+++ b/gallery/tests/gallery.spec.ts
@@ -1,0 +1,300 @@
+import { test, expect, type Page } from '@playwright/test';
+import { sampleVideos } from './fixtures/sample-videos.js';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Intercept the /videos.json request and respond with the provided data.
+ * Must be called before page.goto().
+ */
+async function mockVideos(page: Page, videos: typeof sampleVideos = sampleVideos) {
+	await page.route('**/videos.json', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(videos),
+		});
+	});
+}
+
+/**
+ * Intercept /videos.json and respond with a server error.
+ */
+async function mockVideosError(page: Page, status = 500) {
+	await page.route('**/videos.json', async (route) => {
+		await route.fulfill({ status, body: 'Internal Server Error' });
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Page load & video display
+// ---------------------------------------------------------------------------
+
+test.describe('Gallery page — video display', () => {
+	test('renders the page title in the browser tab', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+		await expect(page).toHaveTitle('Family Videos');
+	});
+
+	test('shows the site name in the navigation bar', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+		await expect(page.getByRole('link', { name: 'Family Videos' })).toBeVisible();
+	});
+
+	test('shows an Admin link in the navigation bar', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+		await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
+	});
+
+	test('displays a video card for each video', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		// Wait for the grid to appear
+		const cards = page.locator('.grid a');
+		await expect(cards).toHaveCount(sampleVideos.length);
+	});
+
+	test('shows video titles in the cards', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		for (const video of sampleVideos) {
+			await expect(page.getByText(video.title).first()).toBeVisible();
+		}
+	});
+
+	test('video cards link to youtube.com', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		const firstCard = page.locator('.grid a').first();
+		const href = await firstCard.getAttribute('href');
+		expect(href).toContain('youtube.com/watch?v=');
+	});
+
+	test('video card opens in a new tab (target=_blank)', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		const firstCard = page.locator('.grid a').first();
+		await expect(firstCard).toHaveAttribute('target', '_blank');
+	});
+
+	test('video card has rel=noopener noreferrer for security', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		const firstCard = page.locator('.grid a').first();
+		const rel = await firstCard.getAttribute('rel');
+		expect(rel).toContain('noopener');
+		expect(rel).toContain('noreferrer');
+	});
+
+	test('shows playlist tags on video cards when video is in a playlist', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		// "Family Vacation 2023" is in the "Vacations" playlist
+		const vacationCard = page.locator('.grid a', { hasText: 'Family Vacation 2023' });
+		await expect(vacationCard.getByText('Vacations')).toBeVisible();
+	});
+
+	test('shows multiple playlist tags when video is in multiple playlists', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		// "Grandma's Birthday Party" is in both "Birthdays" and "Vacations"
+		const birthdayCard = page.locator('.grid a', { hasText: "Grandma's Birthday Party" });
+		await expect(birthdayCard.getByText('Birthdays')).toBeVisible();
+		await expect(birthdayCard.getByText('Vacations')).toBeVisible();
+	});
+
+	test('does not show playlist section on cards with no playlists', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		// "Christmas Morning" has no playlists — its card should have no tag spans
+		const christmasCard = page.locator('.grid a', { hasText: 'Christmas Morning' });
+		// The playlist tags container uses specific classes — check it's absent
+		await expect(christmasCard.locator('.flex.flex-wrap.gap-1')).not.toBeVisible();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Search filtering
+// ---------------------------------------------------------------------------
+
+test.describe('Gallery page — search', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+	});
+
+	test('search box is visible with placeholder text', async ({ page }) => {
+		await expect(page.getByPlaceholder('Search videos...')).toBeVisible();
+	});
+
+	test('filters videos by title', async ({ page }) => {
+		await page.getByPlaceholder('Search videos...').fill('vacation');
+		await expect(page.getByText('Family Vacation 2023')).toBeVisible();
+		await expect(page.getByText('Christmas Morning')).not.toBeVisible();
+	});
+
+	test('filters videos by description', async ({ page }) => {
+		await page.getByPlaceholder('Search videos...').fill('Opening presents');
+		await expect(page.getByText('Christmas Morning')).toBeVisible();
+		await expect(page.getByText('Family Vacation 2023')).not.toBeVisible();
+	});
+
+	test('filters videos by tag', async ({ page }) => {
+		await page.getByPlaceholder('Search videos...').fill('holidays');
+		await expect(page.getByText('Christmas Morning')).toBeVisible();
+		await expect(page.getByText('Family Vacation 2023')).not.toBeVisible();
+	});
+
+	test('filters videos by playlist name', async ({ page }) => {
+		// "Birthdays" playlist only contains "Grandma's Birthday Party"
+		await page.getByPlaceholder('Search videos...').fill('Birthdays');
+		await expect(page.getByText("Grandma's Birthday Party")).toBeVisible();
+		await expect(page.getByText('Family Vacation 2023')).not.toBeVisible();
+	});
+
+	test('search is case-insensitive', async ({ page }) => {
+		await page.getByPlaceholder('Search videos...').fill('CHRISTMAS');
+		await expect(page.getByText('Christmas Morning')).toBeVisible();
+	});
+
+	test('shows "No videos found" message when no results match', async ({ page }) => {
+		await page.getByPlaceholder('Search videos...').fill('xyzzy_nonexistent_query');
+		await expect(page.getByText('No videos found.')).toBeVisible();
+	});
+
+	test('clears filter when search box is emptied', async ({ page }) => {
+		const searchBox = page.getByPlaceholder('Search videos...');
+		await searchBox.fill('vacation');
+		await expect(page.locator('.grid a')).toHaveCount(2); // vacation appears in 2 videos
+
+		await searchBox.fill('');
+		await expect(page.locator('.grid a')).toHaveCount(sampleVideos.length);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Playlist filter buttons
+// ---------------------------------------------------------------------------
+
+test.describe('Gallery page — playlist filter', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+	});
+
+	test('shows playlist filter buttons for each unique playlist', async ({ page }) => {
+		// Sample data has 2 unique playlists: Birthdays, Vacations (sorted)
+		await expect(page.getByRole('button', { name: 'Birthdays' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Vacations' })).toBeVisible();
+	});
+
+	test('shows "All" button in playlist filter', async ({ page }) => {
+		await expect(page.getByRole('button', { name: 'All' })).toBeVisible();
+	});
+
+	test('clicking a playlist button filters to only that playlist\'s videos', async ({
+		page,
+	}) => {
+		await page.getByRole('button', { name: 'Birthdays' }).click();
+
+		// Only "Grandma's Birthday Party" is in Birthdays
+		const cards = page.locator('.grid a');
+		await expect(cards).toHaveCount(1);
+		await expect(cards.first()).toContainText("Grandma's Birthday Party");
+	});
+
+	test('Vacations playlist contains both vacation and birthday videos', async ({ page }) => {
+		await page.getByRole('button', { name: 'Vacations' }).click();
+
+		// Both "Family Vacation 2023" and "Grandma's Birthday Party" are in Vacations
+		const cards = page.locator('.grid a');
+		await expect(cards).toHaveCount(2);
+	});
+
+	test('clicking the "All" button clears the playlist filter', async ({ page }) => {
+		// First select a filter
+		await page.getByRole('button', { name: 'Birthdays' }).click();
+		await expect(page.locator('.grid a')).toHaveCount(1);
+
+		// Then click All to reset
+		await page.getByRole('button', { name: 'All' }).click();
+		await expect(page.locator('.grid a')).toHaveCount(sampleVideos.length);
+	});
+
+	test('clicking an active playlist filter again deselects it', async ({ page }) => {
+		// Select Birthdays
+		await page.getByRole('button', { name: 'Birthdays' }).click();
+		await expect(page.locator('.grid a')).toHaveCount(1);
+
+		// Click it again to deselect (toggle behavior)
+		await page.getByRole('button', { name: 'Birthdays' }).click();
+		await expect(page.locator('.grid a')).toHaveCount(sampleVideos.length);
+	});
+
+	test('playlist filter and search can be combined', async ({ page }) => {
+		// Filter to Vacations (2 videos), then search for "Christmas"
+		await page.getByRole('button', { name: 'Vacations' }).click();
+		await page.getByPlaceholder('Search videos...').fill('beach');
+
+		// Only "Family Vacation 2023" has "beach" in its description/tags
+		const cards = page.locator('.grid a');
+		await expect(cards).toHaveCount(1);
+		await expect(cards.first()).toContainText('Family Vacation 2023');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Playlist filter visibility
+// ---------------------------------------------------------------------------
+
+test.describe('Gallery page — playlist filter visibility', () => {
+	test('playlist filter is not shown when no videos have playlists', async ({ page }) => {
+		const videosWithoutPlaylists = sampleVideos.map((v) => ({ ...v, playlists: [] }));
+		await mockVideos(page, videosWithoutPlaylists as typeof sampleVideos);
+		await page.goto('/');
+
+		// No playlist buttons should appear (not even "All")
+		await expect(page.getByRole('button', { name: 'All' })).not.toBeVisible();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Empty and error states
+// ---------------------------------------------------------------------------
+
+test.describe('Gallery page — empty and error states', () => {
+	test('shows error message when videos.json returns a server error', async ({ page }) => {
+		await mockVideosError(page, 500);
+		await page.goto('/');
+
+		// The app renders the error text
+		await expect(page.getByText(/Failed to fetch videos/)).toBeVisible();
+	});
+
+	test('shows "No videos found" when videos.json returns an empty array', async ({ page }) => {
+		await mockVideos(page, []);
+		await page.goto('/');
+
+		await expect(page.getByText('No videos found.')).toBeVisible();
+	});
+
+	test('does not show the video grid when there are no videos', async ({ page }) => {
+		await mockVideos(page, []);
+		await page.goto('/');
+
+		await expect(page.locator('.grid')).not.toBeVisible();
+	});
+});


### PR DESCRIPTION
Python unit tests (47 tests, run with python3 -m pytest fetch/tests/):
- test_make_simple_video_list.py: covers build_membership_lookup,
  simplify_video (thumbnail fallback, missing fields, privacy status),
  and main() integration with tmp_path fixtures
- test_fetch_videos.py: covers get_credentials (refresh flow, missing
  token), get_all_video_ids / get_all_playlists (pagination), get_video_details
  (50-item batching), get_playlist_memberships (non-video filtering,
  per-playlist pagination) — all Google SDK deps fully mocked

Playwright E2E tests (48 tests, run with npm run test:e2e in gallery/):
- gallery.spec.ts: video display, search filtering (title/description/
  tag/playlist name, case-insensitive), playlist filter buttons (select,
  toggle, All, combined with search), empty/error states
- admin.spec.ts: table structure, column headers, video rows, status
  badges, YouTube Studio links, error/empty states
- Uses page.route() to mock /videos.json — no network required

Also adds:
- fetch/pyproject.toml: [tool.pytest.ini_options] testpaths config
- gallery/playwright.config.ts: webServer + chromium project config
- gallery/package.json: test:e2e / test:e2e:ui / test:e2e:debug scripts

https://claude.ai/code/session_01NMDySuAkwk54niJ9gMuq4c