### PR TITLE
Populate videoDate from YouTube recordingDetails API

### DIFF
--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -12,6 +12,7 @@ Raw response from the YouTube Data API [`videos.list`](https://developers.google
 - **`contentDetails`** — duration, definition, dimension, caption, projection
 - **`statistics`** — view count, like count, comment count
 - **`status`** — privacy status, upload status, embeddable, madeForKids
+- **`recordingDetails`** — date the video was recorded (set manually in YouTube Studio)
 
 Produced by: `fetch_videos.py`
 
@@ -60,7 +61,8 @@ Produced by `make_simple_video_list.py` from `videos_full.json` + `playlists_ful
 | `url` | — | Constructed as `https://www.youtube.com/watch?v={id}` |
 | `title` | `item["snippet"]["title"]` | |
 | `description` | `item["snippet"]["description"]` | |
-| `uploadDate` | `item["snippet"]["publishedAt"]` | ISO 8601 datetime string |
+| `uploadDate` | `item["snippet"]["publishedAt"]` | ISO 8601 datetime — when the video was published to YouTube |
+| `videoDate` | `item["recordingDetails"]["recordingDate"]` | ISO 8601 datetime — when the video was filmed (set in YT Studio). `null` if not set |
 | `tags` | `item["snippet"]["tags"]` | Defaults to `[]` if absent |
 | `privacyStatus` | `item["status"]["privacyStatus"]` | `"public"`, `"unlisted"`, or `"private"` |
 | `thumbnails.high` | `item["snippet"]["thumbnails"]["high"]` | Object with `url`, `width`, `height` |
@@ -79,6 +81,7 @@ Produced by `make_simple_video_list.py` from `videos_full.json` + `playlists_ful
   "title": "My Video Title",
   "description": "A description of the video.",
   "uploadDate": "2024-03-01T14:00:00Z",
+  "videoDate": "2024-02-14T00:00:00Z",
   "tags": ["tutorial", "python"],
   "privacyStatus": "public",
   "thumbnails": {

--- a/fetch/fetch_videos.py
+++ b/fetch/fetch_videos.py
@@ -53,7 +53,7 @@ def get_video_details(youtube, video_ids):
         batch = video_ids[i : i + 50]
         response = youtube.videos().list(
             id=",".join(batch),
-            part="snippet,contentDetails,statistics,status",
+            part="snippet,contentDetails,statistics,status,recordingDetails",
         ).execute()
         all_videos.extend(response["items"])
     return all_videos

--- a/fetch/make_simple_video_list.py
+++ b/fetch/make_simple_video_list.py
@@ -31,6 +31,7 @@ def simplify_video(item, membership_lookup):
     status = item["status"]
     statistics = item.get("statistics", {})
     thumbnails = snippet.get("thumbnails", {})
+    recording = item.get("recordingDetails", {})
 
     high_thumb = thumbnails.get("high")
     standard_thumb = thumbnails.get("standard") or high_thumb
@@ -41,6 +42,7 @@ def simplify_video(item, membership_lookup):
         "title": snippet["title"],
         "description": snippet.get("description", ""),
         "uploadDate": snippet["publishedAt"],
+        "videoDate": recording.get("recordingDate"),
         "tags": snippet.get("tags", []),
         "privacyStatus": status["privacyStatus"],
         "thumbnails": {

--- a/fetch/tests/test_make_simple_video_list.py
+++ b/fetch/tests/test_make_simple_video_list.py
@@ -41,6 +41,7 @@ def make_raw_video(
     view_count="100",
     high_thumb=None,
     standard_thumb=None,
+    recording_date=None,
 ):
     """Build a minimal raw YouTube API video resource."""
     thumbnails = {}
@@ -69,6 +70,8 @@ def make_raw_video(
         video["snippet"]["tags"] = tags
     if category_id is not None:
         video["snippet"]["categoryId"] = category_id
+    if recording_date is not None:
+        video["recordingDetails"] = {"recordingDate": recording_date}
 
     return video
 
@@ -153,6 +156,7 @@ class TestSimplifyVideo:
         assert result["title"] == "My Great Video"
         assert result["description"] == "A thorough description."
         assert result["uploadDate"] == "2024-03-01T14:00:00Z"
+        assert result["videoDate"] is None
         assert result["tags"] == ["tutorial", "python"]
         assert result["privacyStatus"] == "public"
         assert result["thumbnails"]["high"] == THUMB_HIGH
@@ -161,6 +165,23 @@ class TestSimplifyVideo:
         assert result["categoryId"] == "28"
         assert result["viewCount"] == "4321"
         assert result["playlists"] == [{"id": "PL1", "title": "Tech Talks"}]
+
+    def test_video_date_populated_from_recording_date(self):
+        raw = make_raw_video(recording_date="2023-12-25T08:00:00Z")
+        result = simplify_video(raw, {})
+        assert result["videoDate"] == "2023-12-25T08:00:00Z"
+
+    def test_video_date_none_when_recording_details_absent(self):
+        raw = make_raw_video()  # no recordingDetails key at all
+        assert "recordingDetails" not in raw
+        result = simplify_video(raw, {})
+        assert result["videoDate"] is None
+
+    def test_video_date_none_when_recording_date_absent_from_details(self):
+        raw = make_raw_video()
+        raw["recordingDetails"] = {}  # key present but recordingDate missing
+        result = simplify_video(raw, {})
+        assert result["videoDate"] is None
 
     def test_url_constructed_from_video_id(self):
         raw = make_raw_video(video_id="dQw4w9WgXcQ")


### PR DESCRIPTION
Closes #9

## Summary
- Adds `recordingDetails` to the `part=` list in `get_video_details()` so the YouTube API returns the filming date alongside existing fields
- Extracts `recordingDate` → `videoDate` (nullable) in `make_simple_video_list.py`
- Adds 3 unit tests covering: date present, `recordingDetails` key absent, key present but `recordingDate` missing
- Documents the new field in `MAPPINGS.md`

## Test plan
- [x] 50/50 Python tests pass (`uv run pytest tests/ -v`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CemrXnJMbJTtcirQ2354WC)_