### PR TITLE
Add videoDate to gallery test fixtures and e2e coverage

### DIFF
--- a/gallery/tests/fixtures/sample-videos.ts
+++ b/gallery/tests/fixtures/sample-videos.ts
@@ -9,6 +9,7 @@ export const sampleVideos = [
 		title: 'Family Vacation 2023',
 		description: 'Our summer trip to the beach. Fun in the sun!',
 		uploadDate: '2023-07-15T12:00:00Z',
+		videoDate: '2023-07-10T00:00:00Z',
 		tags: ['vacation', 'beach', 'summer'],
 		privacyStatus: 'public',
 		thumbnails: {
@@ -34,6 +35,7 @@ export const sampleVideos = [
 		title: "Grandma's Birthday Party",
 		description: "Celebrating grandma turning 80. A wonderful day with family.",
 		uploadDate: '2023-09-20T15:30:00Z',
+		videoDate: null,
 		tags: ['birthday', 'party', 'grandma'],
 		privacyStatus: 'unlisted',
 		thumbnails: {
@@ -58,6 +60,7 @@ export const sampleVideos = [
 		title: 'Christmas Morning',
 		description: 'Opening presents on Christmas morning.',
 		uploadDate: '2023-12-25T08:00:00Z',
+		videoDate: '2023-12-25T00:00:00Z',
 		tags: ['christmas', 'holidays', 'presents'],
 		privacyStatus: 'public',
 		thumbnails: {

--- a/gallery/tests/gallery.spec.ts
+++ b/gallery/tests/gallery.spec.ts
@@ -375,4 +375,19 @@ test.describe('Video detail page', () => {
 
 		await expect(page.getByText('Video not found.')).toBeVisible();
 	});
+
+	test('shows "Filmed" date on detail page when videoDate is present', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/video/vacationVid1'); // has videoDate: '2023-07-10T00:00:00Z'
+
+		await expect(page.getByText(/Filmed/)).toBeVisible();
+		await expect(page.getByText('Filmed July 10, 2023')).toBeVisible();
+	});
+
+	test('does not show "Filmed" label on detail page when videoDate is absent', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/video/birthdayVid2'); // videoDate: null
+
+		await expect(page.getByText(/Filmed/)).not.toBeVisible();
+	});
 });


### PR DESCRIPTION
Closes #10

## Summary
- Adds `videoDate` to `vacationVid1` and `christmasVid3` in `sample-videos.ts`; `birthdayVid2` is left with `null` to exercise the fallback path
- Adds 2 new e2e tests: "Filmed" label shown on detail page when `videoDate` is present, hidden when absent

## Test plan
- [x] 52/52 Playwright e2e tests pass (`npm run test:e2e`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CemrXnJMbJTtcirQ2354WC)_