### PR TITLE
feat: exclude work videos by default with sidebar toggle

### DIFF
--- a/gallery/src/lib/components/Sidebar.svelte
+++ b/gallery/src/lib/components/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PlaylistRef } from '$lib/types';
-	import { SITE_NAME } from '$lib/config';
+	import { SITE_NAME, EXCLUDED_TAGS } from '$lib/config';
 	import { PUBLIC_BUILD_VERSION } from '$env/static/public';
 
 	const version = PUBLIC_BUILD_VERSION || 'dev';
@@ -9,15 +9,19 @@
 		collections,
 		selectedCollection = $bindable<string | null>(null),
 		sortBy = $bindable<'videoDate' | 'uploadDate' | 'title'>('videoDate'),
+		showExcluded = $bindable(false),
 		videoCounts,
 		totalCount
 	}: {
 		collections: PlaylistRef[];
 		selectedCollection: string | null;
 		sortBy: 'videoDate' | 'uploadDate' | 'title';
+		showExcluded: boolean;
 		videoCounts: Map<string, number>;
 		totalCount: number;
 	} = $props();
+
+	const excludedLabel = EXCLUDED_TAGS.join(', ');
 </script>
 
 <aside class="sidebar flex h-full w-60 shrink-0 flex-col overflow-y-auto">
@@ -72,6 +76,16 @@
 			{/each}
 		</nav>
 	</div>
+
+	<!-- Excluded tags toggle -->
+	{#if EXCLUDED_TAGS.length > 0}
+		<div class="section border-t px-4 py-3" style="border-color: var(--color-border);">
+			<label class="toggle-row">
+				<input type="checkbox" bind:checked={showExcluded} class="toggle-checkbox" />
+				<span class="toggle-label">Show {excludedLabel} videos</span>
+			</label>
+		</div>
+	{/if}
 
 	<!-- People -->
 	<div class="section border-t px-4 py-3" style="border-color: var(--color-border);">
@@ -152,6 +166,26 @@
 	.count {
 		font-size: 11px;
 		color: var(--color-accent-soft);
+	}
+
+	.toggle-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		cursor: pointer;
+	}
+
+	.toggle-checkbox {
+		width: 14px;
+		height: 14px;
+		accent-color: var(--color-accent);
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	.toggle-label {
+		font-size: var(--text-small);
+		color: var(--color-text-soft);
 	}
 
 	.coming-soon {

--- a/gallery/src/lib/config.ts
+++ b/gallery/src/lib/config.ts
@@ -1,2 +1,6 @@
 export const SITE_NAME = 'MegaHirt Gallery';
 export const SITE_SUBTITLE = 'Memories In Motion';
+
+// Videos with any of these tags are hidden by default.
+// Use the sidebar toggle to show them.
+export const EXCLUDED_TAGS: string[] = ['work'];

--- a/gallery/src/routes/+page.svelte
+++ b/gallery/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import type { Video, PlaylistRef } from '$lib/types';
+	import { EXCLUDED_TAGS } from '$lib/config';
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import SearchBar from '$lib/components/SearchBar.svelte';
@@ -27,6 +28,7 @@
 	let density = $state<'large' | 'medium' | 'list'>(
 		(initParams.get('density') as 'large' | 'medium' | 'list') ?? 'medium'
 	);
+	let showExcluded = $state(initParams.get('showExcluded') === '1');
 	let sidebarOpen = $state(false);
 	let canSyncUrl = $state(false);
 
@@ -47,6 +49,9 @@
 		density !== 'medium'
 			? u.searchParams.set('density', density)
 			: u.searchParams.delete('density');
+		showExcluded
+			? u.searchParams.set('showExcluded', '1')
+			: u.searchParams.delete('showExcluded');
 		const next = `${u.pathname}${u.search}${u.hash}`;
 		const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 		if (next !== current) {
@@ -60,6 +65,7 @@
 		selectedCollection;
 		sortBy;
 		density;
+		showExcluded;
 		syncUrl();
 	});
 
@@ -85,6 +91,12 @@
 
 	const filteredVideos = $derived.by<Video[]>(() => {
 		let result = store.videos;
+
+		if (!showExcluded && EXCLUDED_TAGS.length > 0) {
+			result = result.filter(
+				(v) => !v.tags.some((t) => EXCLUDED_TAGS.includes(t))
+			);
+		}
 
 		if (selectedCollection) {
 			result = result.filter((v) => v.playlists.some((p) => p.title === selectedCollection));
@@ -171,6 +183,7 @@
 			{collections}
 			bind:selectedCollection
 			bind:sortBy
+			bind:showExcluded
 			{videoCounts}
 			totalCount={store.videos.length}
 		/>

--- a/gallery/tests/fixtures/sample-videos.ts
+++ b/gallery/tests/fixtures/sample-videos.ts
@@ -36,7 +36,7 @@ export const sampleVideos = [
 		description: "Celebrating grandma turning 80. A wonderful day with family.",
 		uploadDate: '2023-09-20T15:30:00Z',
 		videoDate: null,
-		tags: ['birthday', 'party', 'grandma'],
+		tags: ['birthday', 'party', 'grandma', 'work'],
 		privacyStatus: 'unlisted',
 		thumbnails: {
 			high: {

--- a/gallery/tests/gallery.spec.ts
+++ b/gallery/tests/gallery.spec.ts
@@ -49,22 +49,21 @@ test.describe('Gallery page — video display', () => {
 		await expect(page.getByRole('complementary').getByText('MegaHirt Gallery')).toBeVisible();
 	});
 
-	test('displays a video card for each video', async ({ page }) => {
+	test('displays a video card for each non-excluded video', async ({ page }) => {
 		await mockVideos(page);
 		await page.goto('/');
 
-		// Cards are div[role="button"] elements inside the grid
+		// birthdayVid2 has the 'work' tag and is excluded by default
 		const cards = page.locator('.grid [role="button"]');
-		await expect(cards).toHaveCount(sampleVideos.length);
+		await expect(cards).toHaveCount(sampleVideos.length - 1);
 	});
 
 	test('shows video titles in the cards', async ({ page }) => {
 		await mockVideos(page);
 		await page.goto('/');
 
-		for (const video of sampleVideos) {
-			await expect(page.getByText(video.title).first()).toBeVisible();
-		}
+		await expect(page.getByText('Family Vacation 2023').first()).toBeVisible();
+		await expect(page.getByText('Christmas Morning').first()).toBeVisible();
 	});
 
 	test('clicking a video card navigates to the detail page', async ({ page }) => {
@@ -116,6 +115,42 @@ test.describe('Gallery page — video display', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Excluded tags filter
+// ---------------------------------------------------------------------------
+
+test.describe('Gallery page — excluded tags filter', () => {
+	test('hides videos with excluded tags by default', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		// birthdayVid2 has 'work' tag — should be hidden
+		await expect(page.getByText("Grandma's Birthday Party")).not.toBeVisible();
+		await expect(page.getByText('Family Vacation 2023')).toBeVisible();
+	});
+
+	test('shows excluded videos when toggle is checked', async ({ page }) => {
+		await mockVideos(page);
+		await page.goto('/');
+
+		await page.getByRole('checkbox', { name: /show work videos/i }).check();
+
+		await expect(page.getByText("Grandma's Birthday Party")).toBeVisible();
+	});
+
+	test('shows all videos when no videos have excluded tags', async ({ page }) => {
+		const videosNoWork: object[] = sampleVideos.map((v) => ({
+			...v,
+			tags: (v.tags as readonly string[]).filter((t) => t !== 'work'),
+		}));
+		await mockVideos(page, videosNoWork);
+		await page.goto('/');
+
+		const cards = page.locator('.grid [role="button"]');
+		await expect(cards).toHaveCount(sampleVideos.length);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Search filtering
 // ---------------------------------------------------------------------------
 
@@ -148,10 +183,9 @@ test.describe('Gallery page — search', () => {
 	});
 
 	test('filters videos by playlist name', async ({ page }) => {
-		// "Birthdays" playlist only contains "Grandma's Birthday Party"
+		// "Birthdays" playlist only contains "Grandma's Birthday Party" but it's excluded by default
 		await page.getByPlaceholder('Search videos...').fill('Birthdays');
-		await expect(page.getByText("Grandma's Birthday Party")).toBeVisible();
-		await expect(page.getByText('Family Vacation 2023')).not.toBeVisible();
+		await expect(page.getByText('No videos found.')).toBeVisible();
 	});
 
 	test('search is case-insensitive', async ({ page }) => {
@@ -167,10 +201,12 @@ test.describe('Gallery page — search', () => {
 	test('clears filter when search box is emptied', async ({ page }) => {
 		const searchBox = page.getByPlaceholder('Search videos...');
 		await searchBox.fill('vacation');
-		await expect(page.locator('.grid [role="button"]')).toHaveCount(2); // "vacation" matches 2 videos
+		// Only non-excluded vacation videos visible
+		await expect(page.locator('.grid [role="button"]')).toHaveCount(1);
 
 		await searchBox.fill('');
-		await expect(page.locator('.grid [role="button"]')).toHaveCount(sampleVideos.length);
+		// Back to all non-excluded videos (2 — birthdayVid2 still excluded)
+		await expect(page.locator('.grid [role="button"]')).toHaveCount(sampleVideos.length - 1);
 	});
 });
 
@@ -199,36 +235,31 @@ test.describe('Gallery page — collection filter', () => {
 	}) => {
 		await page.getByRole('button', { name: 'Birthdays' }).click();
 
-		// Only "Grandma's Birthday Party" is in Birthdays
-		const cards = page.locator('.grid [role="button"]');
-		await expect(cards).toHaveCount(1);
-		await expect(cards.first()).toContainText("Grandma's Birthday Party");
+		// birthdayVid2 is in Birthdays but is excluded (work tag) — no results
+		await expect(page.getByText('No videos found.')).toBeVisible();
 	});
 
-	test('Vacations collection contains both vacation and birthday videos', async ({ page }) => {
+	test('Vacations collection shows only non-excluded videos by default', async ({ page }) => {
 		await page.getByRole('button', { name: 'Vacations' }).click();
 
-		// Both "Family Vacation 2023" and "Grandma's Birthday Party" are in Vacations
+		// birthdayVid2 (work tag) is excluded; only vacationVid1 remains
 		const cards = page.locator('.grid [role="button"]');
-		await expect(cards).toHaveCount(2);
+		await expect(cards).toHaveCount(1);
+		await expect(cards.first()).toContainText('Family Vacation 2023');
 	});
 
 	test('clicking "All Videos" clears the collection filter', async ({ page }) => {
-		// First select a filter
 		await page.getByRole('button', { name: 'Birthdays' }).click();
-		await expect(page.locator('.grid [role="button"]')).toHaveCount(1);
-
-		// Then click All Videos to reset
 		await page.getByRole('button', { name: 'All Videos' }).click();
-		await expect(page.locator('.grid [role="button"]')).toHaveCount(sampleVideos.length);
+		// Back to non-excluded videos
+		await expect(page.locator('.grid [role="button"]')).toHaveCount(sampleVideos.length - 1);
 	});
 
 	test('collection filter and search can be combined', async ({ page }) => {
-		// Filter to Vacations (2 videos), then search for "beach"
+		// Filter to Vacations (1 non-excluded video), then search for "beach"
 		await page.getByRole('button', { name: 'Vacations' }).click();
 		await page.getByPlaceholder('Search videos...').fill('beach');
 
-		// Only "Family Vacation 2023" has "beach" in its description/tags
 		const cards = page.locator('.grid [role="button"]');
 		await expect(cards).toHaveCount(1);
 		await expect(cards.first()).toContainText('Family Vacation 2023');
@@ -245,10 +276,8 @@ test.describe('Gallery page — collection filter visibility', () => {
 		await mockVideos(page, videosWithoutPlaylists);
 		await page.goto('/');
 
-		// Individual collection buttons should not appear (Birthdays, Vacations)
 		await expect(page.getByRole('button', { name: 'Birthdays' })).not.toBeVisible();
 		await expect(page.getByRole('button', { name: 'Vacations' })).not.toBeVisible();
-		// "All Videos" is always visible
 		await expect(page.getByRole('button', { name: 'All Videos' })).toBeVisible();
 	});
 });
@@ -261,22 +290,18 @@ test.describe('Gallery page — empty and error states', () => {
 	test('shows error message when videos.json returns a server error', async ({ page }) => {
 		await mockVideosError(page, 500);
 		await page.goto('/');
-
-		// The app renders the error text
 		await expect(page.getByText(/Failed to fetch videos/)).toBeVisible();
 	});
 
 	test('shows "No videos found" when videos.json returns an empty array', async ({ page }) => {
 		await mockVideos(page, []);
 		await page.goto('/');
-
 		await expect(page.getByText('No videos found.')).toBeVisible();
 	});
 
 	test('does not show the video grid when there are no videos', async ({ page }) => {
 		await mockVideos(page, []);
 		await page.goto('/');
-
 		await expect(page.locator('.grid [role="button"]')).toHaveCount(0);
 	});
 });
@@ -340,22 +365,18 @@ test.describe('Video detail page', () => {
 		await mockVideos(page);
 		await page.goto('/');
 		await page.goto('/video/vacationVid1');
-
 		await expect(page.getByText('Family Vacation 2023')).toBeVisible();
 	});
 
 	test('shows a "Back to Gallery" link on the detail page', async ({ page }) => {
 		await mockVideos(page);
 		await page.goto('/video/vacationVid1');
-
 		await expect(page.getByRole('link', { name: /Back to Gallery/ })).toBeVisible();
 	});
 
 	test('shows a play button to load the YouTube embed', async ({ page }) => {
 		await mockVideos(page);
 		await page.goto('/video/vacationVid1');
-
-		// The thumbnail area has an aria-label for the play button
 		await expect(page.getByRole('button', { name: /Play/ })).toBeVisible();
 	});
 
@@ -372,22 +393,19 @@ test.describe('Video detail page', () => {
 	test('shows "Video not found" for unknown video ID', async ({ page }) => {
 		await mockVideos(page);
 		await page.goto('/video/nonexistent-id');
-
 		await expect(page.getByText('Video not found.')).toBeVisible();
 	});
 
 	test('shows "Filmed" date on detail page when videoDate is present', async ({ page }) => {
 		await mockVideos(page);
-		await page.goto('/video/vacationVid1'); // has videoDate: '2023-07-10T00:00:00Z'
-
+		await page.goto('/video/vacationVid1');
 		await expect(page.getByText(/Filmed/)).toBeVisible();
 		await expect(page.getByText('Filmed July 10, 2023')).toBeVisible();
 	});
 
 	test('does not show "Filmed" label on detail page when videoDate is absent', async ({ page }) => {
 		await mockVideos(page);
-		await page.goto('/video/birthdayVid2'); // videoDate: null
-
+		await page.goto('/video/birthdayVid2');
 		await expect(page.getByText(/Filmed/)).not.toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `EXCLUDED_TAGS: string[] = ['work']` to `gallery/src/lib/config.ts`
- Videos with any excluded tag are hidden by default in the gallery
- Sidebar shows a "Show work videos" checkbox toggle to reveal them
- Filter state syncs to URL (`?showExcluded=1`) and restores on page load

## Test plan

- [x] 55/55 Playwright e2e tests pass
- [x] `svelte-check` type check: 0 errors
- [x] New tests: "hides videos with excluded tags by default", "shows excluded videos when toggle is checked", "shows all videos when no videos have excluded tags"
- [ ] Manual: load gallery, confirm work-tagged videos hidden; check sidebar toggle; verify URL param round-trips

---
_Generated by [Claude Code](https://claude.ai/code/session_01CemrXnJMbJTtcirQ2354WC)_