### PR TITLE
feat: split recording date CSV into year/month/day columns

### DIFF
--- a/fetch/export_recording_dates.py
+++ b/fetch/export_recording_dates.py
@@ -2,10 +2,10 @@
 Exports video metadata to a CSV for bulk-editing recording dates.
 
 Reads videos.json and writes recording_dates.csv with columns:
-  video_id, title, upload_date, recording_date, description
+  video_id, title, upload_date, year, month, day, description
 
-Fill in the recording_date column (YYYY-MM-DD format) for each video, then
-run `uv run set_recording_dates.py` to push the dates to YouTube.
+Fill in as much of year/month/day as you know — month and day are optional.
+Run `uv run set_recording_dates.py` to push the dates to YouTube.
 
 Videos that already have a recording date set will be pre-filled.
 """
@@ -18,20 +18,26 @@ HERE = Path(__file__).parent
 VIDEOS_FILE = HERE / "videos.json"
 OUTPUT_FILE = HERE / "recording_dates.csv"
 
-FIELDNAMES = ["video_id", "title", "upload_date", "recording_date", "description"]
+FIELDNAMES = ["video_id", "title", "upload_date", "year", "month", "day", "description"]
 
 
 def build_rows(videos):
     rows = []
     for v in sorted(videos, key=lambda x: x["uploadDate"]):
-        recording_date = v.get("videoDate") or ""
-        if recording_date:
-            recording_date = recording_date[:10]  # YYYY-MM-DD
+        video_date = v.get("videoDate") or ""
+        year = month = day = ""
+        if video_date:
+            parts = video_date[:10].split("-")  # YYYY-MM-DD
+            year = parts[0] if len(parts) > 0 else ""
+            month = parts[1] if len(parts) > 1 else ""
+            day = parts[2] if len(parts) > 2 else ""
         rows.append({
             "video_id": v["id"],
             "title": v["title"],
             "upload_date": v["uploadDate"][:10],
-            "recording_date": recording_date,
+            "year": year,
+            "month": month,
+            "day": day,
             "description": v.get("description", ""),
         })
     return rows
@@ -52,13 +58,13 @@ def main():
         writer.writeheader()
         writer.writerows(rows)
 
-    filled = sum(1 for r in rows if r["recording_date"])
+    filled = sum(1 for r in rows if r["year"])
     print(f"Wrote {len(rows)} videos → {OUTPUT_FILE}")
     print(f"  {filled} already have a recording date, {len(rows) - filled} are blank")
     print()
     print("Next steps:")
     print("  1. Open recording_dates.csv in a spreadsheet")
-    print("  2. Fill in the recording_date column (YYYY-MM-DD) for each video")
+    print("  2. Fill in year (required), month and day are optional")
     print("  3. Run `uv run set_recording_dates.py` to push dates to YouTube")
 
 

--- a/fetch/set_recording_dates.py
+++ b/fetch/set_recording_dates.py
@@ -1,9 +1,11 @@
 """
 Reads recording_dates.csv and sets the recording date on each YouTube video
-that has a recording_date value filled in.
+that has a year value filled in.
 
-Run `uv run export_recording_dates.py` first to generate the CSV, fill in the
-recording_date column (YYYY-MM-DD), then run this script.
+Run `uv run export_recording_dates.py` first to generate the CSV, fill in at
+least the year column (month and day are optional), then run this script.
+
+Missing month defaults to 01; missing day defaults to 01.
 
 Requires token_write.json (write-scope token). Generate it with:
   uv run login_write.py
@@ -11,7 +13,6 @@ Requires token_write.json (write-scope token). Generate it with:
 
 import csv
 import time
-from datetime import date
 from pathlib import Path
 
 from google.auth.transport.requests import Request
@@ -39,10 +40,27 @@ def get_credentials():
     return creds
 
 
-def parse_date(date_str):
-    """Parse YYYY-MM-DD and return RFC 3339 string expected by the YouTube API."""
-    d = date.fromisoformat(date_str.strip())
-    return f"{d.isoformat()}T00:00:00.000Z"
+def build_recording_date(year, month, day):
+    """Build RFC 3339 date string from year/month/day, defaulting missing parts to 01.
+
+    Returns (date_str, display_str) or raises ValueError for invalid values.
+    """
+    y = year.strip()
+    m = month.strip() or "01"
+    d = day.strip() or "01"
+    if not y:
+        raise ValueError("year is required")
+    # Validate by constructing; raises ValueError on bad values
+    y_int = int(y)
+    m_int = int(m)
+    d_int = int(d)
+    if not (1 <= m_int <= 12):
+        raise ValueError(f"month {m!r} out of range 1-12")
+    if not (1 <= d_int <= 31):
+        raise ValueError(f"day {d!r} out of range 1-31")
+    iso = f"{y_int:04d}-{m_int:02d}-{d_int:02d}"
+    display = y if not month.strip() else (f"{y}-{m}" if not day.strip() else iso)
+    return f"{iso}T00:00:00.000Z", display
 
 
 def load_rows(path):
@@ -58,10 +76,10 @@ def main():
         )
 
     rows = load_rows(INPUT_FILE)
-    to_update = [r for r in rows if r.get("recording_date", "").strip()]
+    to_update = [r for r in rows if r.get("year", "").strip()]
 
     if not to_update:
-        print("No rows with recording_date filled in. Nothing to do.")
+        print("No rows with year filled in. Nothing to do.")
         return
 
     print(f"Found {len(to_update)} videos to update (out of {len(rows)} total).")
@@ -75,12 +93,15 @@ def main():
     for i, row in enumerate(to_update, 1):
         video_id = row["video_id"].strip()
         title = row["title"]
-        date_str = row["recording_date"].strip()
 
         try:
-            recording_date = parse_date(date_str)
-        except ValueError:
-            print(f"  [{i}/{len(to_update)}] SKIP  {title!r} — invalid date {date_str!r} (use YYYY-MM-DD)")
+            recording_date, display = build_recording_date(
+                row.get("year", ""),
+                row.get("month", ""),
+                row.get("day", ""),
+            )
+        except ValueError as e:
+            print(f"  [{i}/{len(to_update)}] SKIP  {title!r} — {e}")
             errors += 1
             continue
 
@@ -92,7 +113,7 @@ def main():
                     "recordingDetails": {"recordingDate": recording_date},
                 },
             ).execute()
-            print(f"  [{i}/{len(to_update)}] OK    {title!r} → {date_str}")
+            print(f"  [{i}/{len(to_update)}] OK    {title!r} → {display}")
             updated += 1
         except HttpError as e:
             print(f"  [{i}/{len(to_update)}] ERR   {title!r} — {e}")

--- a/fetch/tests/test_export_recording_dates.py
+++ b/fetch/tests/test_export_recording_dates.py
@@ -1,5 +1,5 @@
 """
-Unit tests for export_recording_dates.py.
+Unit tests for export_recording_dates.py and set_recording_dates.build_recording_date.
 """
 
 import csv
@@ -12,6 +12,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from export_recording_dates import build_rows, main, FIELDNAMES
+from set_recording_dates import build_recording_date
 
 
 def make_video(video_id="vid1", title="Test", upload_date="2024-03-01T14:00:00Z",
@@ -34,15 +35,19 @@ class TestBuildRows:
         assert rows[0]["title"] == "My Video"
         assert rows[0]["upload_date"] == "2024-06-01"
 
-    def test_recording_date_blank_when_video_date_absent(self):
+    def test_year_month_day_blank_when_video_date_absent(self):
         videos = [make_video(video_date=None)]
         rows = build_rows(videos)
-        assert rows[0]["recording_date"] == ""
+        assert rows[0]["year"] == ""
+        assert rows[0]["month"] == ""
+        assert rows[0]["day"] == ""
 
-    def test_recording_date_trimmed_to_date_only(self):
+    def test_year_month_day_split_from_video_date(self):
         videos = [make_video(video_date="2023-12-25T00:00:00.000Z")]
         rows = build_rows(videos)
-        assert rows[0]["recording_date"] == "2023-12-25"
+        assert rows[0]["year"] == "2023"
+        assert rows[0]["month"] == "12"
+        assert rows[0]["day"] == "25"
 
     def test_description_included(self):
         videos = [make_video(description="Family trip to the beach.")]
@@ -65,6 +70,45 @@ class TestBuildRows:
         videos = [make_video(upload_date="2023-07-15T12:34:56Z")]
         rows = build_rows(videos)
         assert rows[0]["upload_date"] == "2023-07-15"
+
+    def test_fieldnames_has_split_columns(self):
+        assert "year" in FIELDNAMES
+        assert "month" in FIELDNAMES
+        assert "day" in FIELDNAMES
+        assert "recording_date" not in FIELDNAMES
+
+
+class TestBuildRecordingDate:
+    def test_full_date(self):
+        rfc, display = build_recording_date("2023", "07", "10")
+        assert rfc == "2023-07-10T00:00:00.000Z"
+        assert display == "2023-07-10"
+
+    def test_year_and_month_only(self):
+        rfc, display = build_recording_date("2023", "07", "")
+        assert rfc == "2023-07-01T00:00:00.000Z"
+        assert display == "2023-07"
+
+    def test_year_only(self):
+        rfc, display = build_recording_date("2023", "", "")
+        assert rfc == "2023-01-01T00:00:00.000Z"
+        assert display == "2023"
+
+    def test_missing_year_raises(self):
+        with pytest.raises(ValueError, match="year is required"):
+            build_recording_date("", "07", "10")
+
+    def test_invalid_month_raises(self):
+        with pytest.raises(ValueError, match="month"):
+            build_recording_date("2023", "13", "")
+
+    def test_invalid_day_raises(self):
+        with pytest.raises(ValueError, match="day"):
+            build_recording_date("2023", "07", "32")
+
+    def test_whitespace_stripped(self):
+        rfc, _ = build_recording_date("  2023  ", "  07  ", "  10  ")
+        assert rfc == "2023-07-10T00:00:00.000Z"
 
 
 class TestMain:
@@ -92,9 +136,13 @@ class TestMain:
 
         assert len(rows) == 2
         assert rows[0]["video_id"] == "v1"
-        assert rows[0]["recording_date"] == ""
+        assert rows[0]["year"] == ""
+        assert rows[0]["month"] == ""
+        assert rows[0]["day"] == ""
         assert rows[1]["video_id"] == "v2"
-        assert rows[1]["recording_date"] == "2022-12-25"
+        assert rows[1]["year"] == "2022"
+        assert rows[1]["month"] == "12"
+        assert rows[1]["day"] == "25"
 
     def test_raises_if_videos_json_missing(self, tmp_path, monkeypatch):
         import export_recording_dates as erd


### PR DESCRIPTION
## Summary

- `recording_dates.csv` now has `year`, `month`, `day` columns instead of a single `recording_date` column
- Allows partial dates — fill in only what you know; missing month/day default to `01` when pushing to YouTube
- `export_recording_dates.py` pre-fills all three columns by splitting existing `videoDate` values
- `set_recording_dates.py` skips rows with blank `year`; builds display string matching precision (`2023`, `2023-07`, or `2023-07-10`)

## Test plan

- [x] 81/81 Python tests pass (17 tests for this module, including `TestBuildRecordingDate` covering full/partial/invalid inputs)
- [ ] Manual: `uv run export_recording_dates.py` → open CSV, fill in partial dates → `uv run set_recording_dates.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CemrXnJMbJTtcirQ2354WC)_